### PR TITLE
Add static Swipelist marketing site with FTPS deploy

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{html,css,js,yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: FTP Deploy
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
+        with:
+          server: ${{ secrets.HOSTINGER_FTP_SERVER }}
+          username: ${{ secrets.HOSTINGER_FTP_USERNAME }}
+          password: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
+          port: ${{ secrets.HOSTINGER_FTP_PORT }}
+          protocol: ftps
+          local-dir: site
+          server-dir: ${{ secrets.HOSTINGER_SERVER_DIR }}
+          log-level: standard
+          dangerous-clean-slate: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+node_modules/
+dist/
+*.log
+.env
+preview/
+.cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# swipelistwebsite
-website for swipelist
+# Swipelist Marketing Site
+
+Minimal static marketing website for the Swipelist Android app.
+
+## Develop
+
+1. Ensure Python 3 is installed.
+2. Serve the site locally:
+   ```bash
+   python3 -m http.server --directory site 8080
+   ```
+   Then visit [http://localhost:8080](http://localhost:8080).
+
+## Deployment
+
+GitHub Actions deploys the contents of `/site` to Hostinger via FTPS whenever you push to `main`. The workflow uses [`SamKirkland/FTP-Deploy-Action@v4.3.4`](https://github.com/SamKirkland/FTP-Deploy-Action).
+
+### Required GitHub secrets
+
+Set these in **Settings → Secrets and variables → Actions**:
+
+- `HOSTINGER_FTP_SERVER`  = `ftp.yourdomain.com`
+- `HOSTINGER_FTP_USERNAME` = `your_ftp_user`
+- `HOSTINGER_FTP_PASSWORD` = `your_ftp_password`
+- `HOSTINGER_FTP_PORT`    = `21`
+- `HOSTINGER_SERVER_DIR`  = `/public_html` *(or `/domains/yourdomain.com/public_html`)*
+
+Commit to `main` to trigger deployment. Site files in `/site` should appear on the server directory. If Hostinger uses a domain subfolder, update `HOSTINGER_SERVER_DIR` accordingly.

--- a/site/app.js
+++ b/site/app.js
@@ -1,0 +1,25 @@
+// Smooth scroll for anchor links
+document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+  anchor.addEventListener('click', e => {
+    const target = document.querySelector(anchor.getAttribute('href'));
+    if (target) {
+      e.preventDefault();
+      target.scrollIntoView({ behavior: 'smooth' });
+    }
+  });
+});
+
+// Email form no-op handler
+const form = document.getElementById('mc-form');
+if (form) {
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    console.log('TODO: hook into MailerLite/HubSpot');
+  });
+}
+
+// TODO: Add analytics (GTag)
+// TODO: Add consent logic
+
+// Update year in footer
+document.getElementById('year').textContent = new Date().getFullYear();

--- a/site/assets/logo.svg
+++ b/site/assets/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Swipelist logo">
+  <circle cx="32" cy="32" r="32" fill="#4caf50"/>
+  <path d="M20 32l8 8 16-16" stroke="#fff" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="20" y="18" width="24" height="4" rx="2" fill="#fff"/>
+  <rect x="20" y="26" width="24" height="4" rx="2" fill="#fff"/>
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="description" content="Swipelist — Smarter Grocery Lists" />
+  <meta name="theme-color" content="#4caf50" />
+  <meta property="og:title" content="Swipelist — Smarter Grocery Lists" />
+  <meta property="og:description" content="Reorder categories to match the store you're in; the list auto-sorts as you shop." />
+  <meta property="og:image" content="/assets/logo.svg" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://swipelist.app/" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Swipelist — Smarter Grocery Lists" />
+  <meta name="twitter:description" content="Reorder categories to match the store you're in; the list auto-sorts as you shop." />
+  <meta name="twitter:image" content="/assets/logo.svg" />
+  <title>Swipelist — Smarter Grocery Lists</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+<div id="cookie-banner">TODO: cookie consent</div>
+<header class="container">
+  <img src="/assets/logo.svg" alt="Swipelist logo" class="logo" />
+  <nav aria-label="Primary">
+    <a class="btn" href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist">Get on Google Play</a>
+    <a class="btn outline" href="#mc-form">Join the mailing list</a>
+  </nav>
+</header>
+<main>
+  <section class="hero container">
+    <h1>Swipelist — Smarter Grocery Lists</h1>
+    <p class="subhead">Reorder categories to match the store you're in; the list auto-sorts as you shop.</p>
+  </section>
+  <section class="features container" id="features">
+    <h2>Features</h2>
+    <div class="grid">
+      <div class="tile"><h3>Swipe to delete</h3><p>Remove items with a quick swipe.</p></div>
+      <div class="tile"><h3>Store-aware sorting</h3><p>Categories reorder to match each store.</p></div>
+      <div class="tile"><h3>Share lists</h3><p>Collaborate in real time with family.</p></div>
+      <div class="tile"><h3>Offline-ready</h3><p>Your lists work even without internet.</p></div>
+    </div>
+  </section>
+  <section class="how container">
+    <h2>How it works</h2>
+    <ol>
+      <li>Create your list and set category order per store.</li>
+      <li>As you shop, swipe items to check them off.</li>
+      <li>Share lists to stay in sync with others.</li>
+    </ol>
+  </section>
+  <section class="signup container">
+    <h2>Stay in the loop</h2>
+    <form id="mc-form" aria-label="Join our mailing list">
+      <label for="mc-email" class="visually-hidden">Email address</label>
+      <input id="mc-email" type="email" required placeholder="you@example.com" />
+      <button type="submit">Subscribe</button>
+      <!-- TODO: Hook into MailerLite/HubSpot -->
+    </form>
+  </section>
+  <section class="faq container">
+    <h2>FAQ</h2>
+    <details>
+      <summary>Is Swipelist free?</summary>
+      <p>Yes, the core app is free to use.</p>
+    </details>
+    <details>
+      <summary>Can I share lists with my family?</summary>
+      <p>Absolutely, send them an invite and edit together.</p>
+    </details>
+    <details>
+      <summary>Does it work offline?</summary>
+      <p>Yes, your lists sync when you're back online.</p>
+    </details>
+  </section>
+</main>
+<footer class="container">
+  <p>&copy; <span id="year"></span> Swipelist</p>
+  <nav aria-label="Legal">
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
+    <a href="mailto:support@swipelist.app">Contact</a>
+  </nav>
+</footer>
+<script src="app.js" defer></script>
+</body>
+</html>

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://swipelist.app/sitemap.xml

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://swipelist.app/</loc>
+    <lastmod>2025-09-03</lastmod>
+  </url>
+</urlset>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,112 @@
+:root {
+  --brand: #4caf50;
+  --brand-contrast: #ffffff;
+  --bg: #ffffff;
+  --text: #222222;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #111111;
+    --text: #eeeeee;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0;
+}
+.logo {
+  height: 40px;
+}
+nav .btn {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: var(--brand);
+  color: var(--brand-contrast);
+  text-decoration: none;
+  border-radius: 4px;
+}
+nav .btn.outline {
+  background: none;
+  border: 1px solid var(--brand);
+  color: var(--brand);
+}
+.hero {
+  text-align: center;
+  padding: 3rem 0;
+}
+.subhead {
+  font-size: 1.25rem;
+}
+.features .grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+.tile {
+  background: rgba(0, 0, 0, 0.03);
+  padding: 1rem;
+  border-radius: 4px;
+}
+@media (prefers-color-scheme: dark) {
+  .tile {
+    background: rgba(255, 255, 255, 0.1);
+  }
+}
+.how ol {
+  padding-left: 1.5rem;
+}
+.signup form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+}
+.signup input {
+  padding: 0.5rem;
+  flex: 1 0 200px;
+}
+.signup button {
+  padding: 0.5rem 1rem;
+  background: var(--brand);
+  color: var(--brand-contrast);
+  border: none;
+  border-radius: 4px;
+}
+.faq details {
+  margin-bottom: 0.5rem;
+}
+footer {
+  text-align: center;
+  padding: 2rem 0;
+  font-size: 0.875rem;
+}
+footer nav a {
+  margin: 0 0.5rem;
+  color: var(--brand);
+}
+#cookie-banner {
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  padding: 0.5rem;
+  text-align: center;
+  font-size: 0.875rem;
+}
+.visually-hidden {
+  position: absolute;
+  left: -9999px;
+}


### PR DESCRIPTION
## Summary
- build lightweight Swipelist landing page with hero, feature grid, email capture, FAQ and footer
- add CSS/JS with brand variables and smooth scrolling
- configure GitHub Actions for FTPS deploy to Hostinger

## Testing
- `npx --yes htmlhint site/index.html`
- `npx --yes stylelint site/styles.css` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_68b7daab4728832292d5ce86ad681e38