### PR TITLE
Remove header logo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,6 @@
 <body>
 <div id="cookie-banner">TODO: cookie consent</div>
 <header class="container">
-  <img src="/assets/logo.svg" alt="Swipelist logo" class="logo" />
   <nav aria-label="Primary">
     <a class="btn" href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist">Get on Google Play</a>
     <a class="btn outline" href="#mc-form">Join the mailing list</a>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -24,12 +24,9 @@ body {
 }
 header {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   padding: 1rem 0;
-}
-.logo {
-  height: 40px;
 }
 nav .btn {
   display: inline-block;


### PR DESCRIPTION
## Summary
- remove Swipelist logo from header to eliminate green circle
- adjust header CSS to keep navigation aligned right

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b88408d4288322bc40d32844b805bb