### PR TITLE
Add demo video section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,30 @@
   <meta property="og:url" content="https://swipelist.co.uk/">
   <meta property="og:image" content="favicon.svg">
   <link rel="stylesheet" href="styles.css">
+  <style>
+    .video-section{padding:4rem 0;text-align:center}
+    .video-section .caption{color:var(--muted)}
+    .video-wrapper{position:relative;max-width:900px;margin:2rem auto 0;aspect-ratio:16/9}
+    .video-wrapper iframe,.video-wrapper img{width:100%;height:100%;border-radius:8px}
+    .video-thumb{display:block;width:100%;height:100%;border:0;padding:0;background:none;cursor:pointer;position:relative}
+    .play-icon{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:68px;height:48px}
+    .play-icon circle{fill:rgba(0,0,0,0.6)}
+    .play-icon polygon{fill:#fff}
+  </style>
   <script src="script.js" defer></script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "VideoObject",
+    "name": "Swipelist demo",
+    "description": "Quick demo showing how Swipelist auto-sorts your shopping list.",
+    "thumbnailUrl": "https://i.ytimg.com/vi/ShF5-laPER4/hqdefault.jpg",
+    "uploadDate": "2024-01-01",
+    "duration": "PT1M0S",
+    "contentUrl": "https://www.youtube-nocookie.com/embed/ShF5-laPER4",
+    "embedUrl": "https://www.youtube-nocookie.com/embed/ShF5-laPER4"
+  }
+  </script>
 </head>
 <body>
 <header>
@@ -80,6 +103,19 @@
       </svg>
       <svg class="shape star" viewBox="0 0 20 20" aria-hidden="true"><polygon points="10,0 12,7 20,7 14,11 16,18 10,14 4,18 6,11 0,7 8,7"/></svg>
       <svg class="shape dot" viewBox="0 0 10 10" aria-hidden="true"><circle cx="5" cy="5" r="5"/></svg>
+    </div>
+  </section>
+  <section id="demo" class="video-section">
+    <h2>See it in action</h2>
+    <p class="caption">Watch how Swipelist speeds up your shop.</p>
+    <div class="video-wrapper" aria-label="Swipelist demo video">
+      <button class="video-thumb" aria-label="Play Swipelist demo video">
+        <img src="https://i.ytimg.com/vi/ShF5-laPER4/hqdefault.jpg" alt="Swipelist demo thumbnail" loading="lazy">
+        <svg class="play-icon" viewBox="0 0 100 100" aria-hidden="true">
+          <circle cx="50" cy="50" r="40"/>
+          <polygon points="45,35 70,50 45,65"/>
+        </svg>
+      </button>
     </div>
   </section>
   <section class="trust">
@@ -212,5 +248,23 @@
   </div>
   <p class="copy">© 2024 Swipelist</p>
 </footer>
+<script>
+document.addEventListener('DOMContentLoaded',function(){
+  var btn=document.querySelector('.video-thumb');
+  if(btn){
+    btn.addEventListener('click',function(){
+      var wrapper=btn.parentNode;
+      var iframe=document.createElement('iframe');
+      iframe.src='https://www.youtube-nocookie.com/embed/ShF5-laPER4?autoplay=1&cc_load_policy=1';
+      iframe.title='Swipelist demo video';
+      iframe.allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
+      iframe.allowFullscreen=true;
+      iframe.loading='lazy';
+      wrapper.innerHTML='';
+      wrapper.appendChild(iframe);
+    });
+  }
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- embed Swipelist demo video under hero section with responsive 16:9 lazy-loaded player
- style and script to support click-to-play YouTube-nocookie embed
- add VideoObject structured data for SEO

## Testing
- `npx --yes htmlhint docs/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68bf47a0713483228894f9605bd9cc2e