### PR TITLE
Add app-ads.txt for ad inventory transparency

### DIFF
--- a/docs/app-ads.txt
+++ b/docs/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-5403961907571147, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- add `app-ads.txt` to site root declaring Google ad publisher ID

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c69f07e5fc83229cecc4fe8cb075b6