### PR TITLE
Link homepage CTA buttons to Google Play Store

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -61,7 +61,7 @@
         <li><a href="#features">Features</a></li>
         <li><a href="#pricing">Pricing</a></li>
         <li><a href="#contact">Contact</a></li>
-        <li><a class="btn primary" href="#pricing">Get the App</a></li>
+        <li><a class="btn primary" href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" target="_blank" rel="noopener">Get the App</a></li>
       </ul>
     </nav>
   </div>
@@ -73,7 +73,7 @@
       <h1>Everything for your shopping list to succeed.</h1>
       <p>Swipelist auto-sorts your list by the order you shop, so you fly through the store without back-tracking.</p>
       <div class="actions">
-        <a href="#pricing" class="btn primary">Get Started</a>
+        <a href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" class="btn primary" target="_blank" rel="noopener">Get Started</a>
         <a href="#features" class="btn ghost">Learn More</a>
       </div>
       <p class="note">Starting at £0 / Free app</p>
@@ -194,7 +194,7 @@
     <div class="card">
       <h2>Free forever</h2>
       <p>Swipelist<br><small>Optional Pro coming later.</small></p>
-      <a href="#contact" class="btn primary">Get The App</a>
+      <a href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" class="btn primary" target="_blank" rel="noopener">Get The App</a>
     </div>
   </section>
   <section class="faq">


### PR DESCRIPTION
## Summary
- Link navigation bar "Get the App" button to Google Play Store and open in new tab.
- Update homepage "Get Started" and pricing "Get The App" CTAs to the same Play Store link with new-tab behavior.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fefb534483228292dda733bb1c44