### PR TITLE
Add privacy policy page and footer link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -240,6 +240,7 @@
       <a href="#features">Features</a>
       <a href="#pricing">Pricing</a>
       <a href="#contact">Contact</a>
+      <a href="/privacy">Privacy Policy</a>
     </nav>
     <div class="social">
       <a href="https://twitter.com" aria-label="Twitter"><svg class="icon" aria-hidden="true"><use href="assets/icons.svg#icon-twitter"></use></svg></a>

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Privacy Policy - Swipelist</title>
+  <meta name="description" content="Read the Swipelist Privacy Policy to learn how we collect, use, and protect your data.">
+  <link rel="icon" href="../favicon.svg" type="image/svg+xml">
+  <link rel="manifest" href="../manifest.json">
+  <meta name="theme-color" content="#37C1F3">
+  <link rel="stylesheet" href="../styles.css">
+  <script src="../script.js" defer></script>
+</head>
+<body>
+<header>
+  <div class="container">
+    <a href="/#home" class="brand" aria-label="Swipelist home">
+      <svg class="logo" viewBox="0 0 100 100" aria-hidden="true">
+        <circle cx="50" cy="50" r="48" fill="var(--blue-500)"/>
+        <path d="M25 30l8 8 14-14M25 50l8 8 14-14M25 70l8 8 14-14" fill="none" stroke="#fff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M60 30h22M60 50h22M60 70h22" stroke="#fff" stroke-width="6" stroke-linecap="round"/>
+      </svg>
+      <span>Swipelist</span>
+    </a>
+    <button class="menu-toggle" aria-label="Toggle menu">
+      <span></span><span></span><span></span>
+    </button>
+    <nav>
+      <ul>
+        <li><a href="/#home">Home</a></li>
+        <li><a href="/#features">Features</a></li>
+        <li><a href="/#pricing">Pricing</a></li>
+        <li><a href="/#contact">Contact</a></li>
+        <li><a class="btn primary" href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" target="_blank" rel="noopener">Get the App</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>
+<main class="legal">
+  <section class="legal-hero">
+    <div class="container">
+      <h1>Privacy Policy</h1>
+      <p class="effective-date">Effective Date: 17/09/2025</p>
+      <p>Swipelist (“the App”, “we”, “our”, “us”) respects your privacy and is committed to protecting it. This Privacy Policy explains how we collect, use, and safeguard your information when you use our mobile application and website.</p>
+    </div>
+  </section>
+  <section class="legal-content">
+    <div class="container">
+      <article class="legal-card" aria-label="Privacy Policy details">
+        <section>
+          <h2>1. Information We Collect</h2>
+          <ul>
+            <li><strong>Device Information:</strong> We may collect non-personal information such as device type, operating system, and unique identifiers (e.g., advertising ID).</li>
+            <li><strong>Usage Data:</strong> We collect information on how you use the App, such as pages viewed, features used, and session length.</li>
+            <li><strong>Advertising Data:</strong> Through Google AdMob, we collect information to serve personalized and non-personalized ads.</li>
+          </ul>
+          <p>We do not collect personally identifiable information (such as your name, email, or contact details) unless you voluntarily provide it (e.g., through contacting us).</p>
+        </section>
+        <section>
+          <h2>2. How We Use Information</h2>
+          <p>We use the information we collect to:</p>
+          <ul>
+            <li>Provide, operate, and improve the App.</li>
+            <li>Serve relevant advertisements through Google AdMob.</li>
+            <li>Monitor usage and performance.</li>
+            <li>Comply with legal obligations.</li>
+          </ul>
+        </section>
+        <section>
+          <h2>3. Third-Party Services</h2>
+          <p>We use Google AdMob for advertising. AdMob may collect and use device identifiers and cookies to personalize ads. For more details, please review <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Google’s Privacy Policy</a>.</p>
+        </section>
+        <section>
+          <h2>4. Children’s Privacy</h2>
+          <p>Swipelist is not directed toward children under the age of 13. We do not knowingly collect information from children. If you believe your child has provided information, please contact us so we can delete it.</p>
+        </section>
+        <section>
+          <h2>5. Data Sharing</h2>
+          <p>We do not sell, trade, or rent your personal information. We may share aggregated or anonymized data with trusted partners for analytics and advertising purposes.</p>
+        </section>
+        <section>
+          <h2>6. Data Security</h2>
+          <p>We implement reasonable measures to protect your information. However, no method of electronic storage or transmission is 100% secure, and we cannot guarantee absolute security.</p>
+        </section>
+        <section>
+          <h2>7. Your Choices</h2>
+          <ul>
+            <li>You can manage your ad preferences through your device settings.</li>
+            <li>You may opt out of personalized advertising via <a href="https://www.google.com/settings/ads" target="_blank" rel="noopener">Google Ads Settings</a>.</li>
+          </ul>
+        </section>
+        <section>
+          <h2>8. Contact Us</h2>
+          <p>If you have any questions about this Privacy Policy, please contact us:</p>
+          <p>📧 <a href="mailto:pz22pzpz@gmail.com">pz22pzpz@gmail.com</a></p>
+        </section>
+      </article>
+    </div>
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <a href="/#home" class="brand" aria-label="Swipelist home">
+      <svg class="logo" viewBox="0 0 100 100" aria-hidden="true">
+        <circle cx="50" cy="50" r="48" fill="var(--blue-500)"/>
+        <path d="M25 30l8 8 14-14M25 50l8 8 14-14M25 70l8 8 14-14" fill="none" stroke="#fff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M60 30h22M60 50h22M60 70h22" stroke="#fff" stroke-width="6" stroke-linecap="round"/>
+      </svg>
+      <span>Swipelist</span>
+    </a>
+    <nav class="foot-nav">
+      <a href="/#features">Features</a>
+      <a href="/#pricing">Pricing</a>
+      <a href="/#contact">Contact</a>
+      <a href="/privacy">Privacy Policy</a>
+    </nav>
+    <div class="social">
+      <a href="https://twitter.com" aria-label="Twitter"><svg class="icon" aria-hidden="true"><use href="../assets/icons.svg#icon-twitter"></use></svg></a>
+      <a href="https://github.com" aria-label="GitHub"><svg class="icon" aria-hidden="true"><use href="../assets/icons.svg#icon-github"></use></svg></a>
+    </div>
+  </div>
+  <p class="copy">© 2024 Swipelist</p>
+</footer>
+</body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -77,9 +77,22 @@ footer .social a{margin-left:.5rem;color:#fff;}
 footer .social a:hover,footer .social a:focus{color:var(--blue-50);}
 .copy{text-align:center;margin-top:1rem;font-size:.875rem;color:var(--blue-50);}
 :focus-visible{outline:2px dashed var(--blue-700);outline-offset:2px;}
+.legal-hero{padding:4rem 0 2rem;text-align:center;background:linear-gradient(135deg,var(--blue-50),var(--bg));}
+.legal-hero h1{margin-bottom:.5rem;font-size:2.5rem;}
+.legal-hero .effective-date{color:var(--muted);font-weight:600;}
+.legal-content{padding:0 0 4rem;}
+.legal-card{background:var(--card);border-radius:12px;box-shadow:0 10px 30px rgba(10,134,198,0.12);padding:2.5rem;margin:0 auto;max-width:900px;}
+.legal-card section+section{margin-top:2rem;}
+.legal-card h2{margin-top:0;color:var(--blue-700);}
+.legal-card p{margin:0 0 1rem;color:var(--ink);}
+.legal-card ul{margin:0 0 1rem;padding-left:1.25rem;color:var(--muted);}
+.legal-card li{margin-bottom:.5rem;}
+.legal-card a{color:var(--blue-700);text-decoration:underline;}
 @media (max-width:768px){
   nav{position:absolute;top:100%;right:0;background:var(--bg);width:200px;max-height:0;overflow:hidden;transition:max-height .3s ease;box-shadow:0 4px 8px rgba(0,0,0,0.1);}
   nav ul{flex-direction:column;padding:1rem;}
   nav.open{max-height:300px;}
   .menu-toggle{display:flex;}
+  .legal-hero h1{font-size:2.1rem;}
+  .legal-card{padding:1.75rem;}
 }


### PR DESCRIPTION
## Summary
- add a dedicated privacy policy page that mirrors the Swipelist branding
- extend the shared stylesheet with light-blue themed legal page styles
- link the privacy policy from the global footer for desktop and mobile

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ca46fc4b4c8322adef43d1d12e5f8f