### PR TITLE
Add app-ads.txt for AdMob authorization

### DIFF
--- a/app-ads.txt
+++ b/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-5403961907571147, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- add an app-ads.txt file at the site root containing the AdMob authorized seller entry

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca654f80dc83228d27b6d052c0e324