### PR TITLE
Replace Play Store buttons with inline badge

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -61,7 +61,18 @@
         <li><a href="#features">Features</a></li>
         <li><a href="#pricing">Pricing</a></li>
         <li><a href="#contact">Contact</a></li>
-        <li><a class="btn primary" href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" target="_blank" rel="noopener">Get the App</a></li>
+        <li>
+          <a class="google-play-badge" href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" target="_blank" rel="noopener noreferrer" aria-label="Get it on Google Play">
+            <svg xmlns="http://www.w3.org/2000/svg" width="200" height="60" viewBox="0 0 512 152" aria-hidden="true">
+              <rect width="512" height="152" fill="black" rx="8" ry="8"/>
+              <text x="130" y="95" font-family="Arial, sans-serif" font-size="40" fill="white">Google Play</text>
+              <polygon points="40,25 100,75 40,125" fill="#34A853"/>
+              <polygon points="40,25 40,125 75,100" fill="#FBBC05"/>
+              <polygon points="40,25 75,50 100,75 75,100 40,125" fill="#4285F4" fill-opacity="0.7"/>
+              <polygon points="75,50 100,75 75,100" fill="#EA4335"/>
+            </svg>
+          </a>
+        </li>
       </ul>
     </nav>
   </div>
@@ -73,7 +84,16 @@
       <h1>Everything for your shopping list to succeed.</h1>
       <p>Swipelist auto-sorts your list by the order you shop, so you fly through the store without back-tracking.</p>
       <div class="actions">
-        <a href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" class="btn primary" target="_blank" rel="noopener">Get Started</a>
+        <a class="google-play-badge" href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" target="_blank" rel="noopener noreferrer" aria-label="Get it on Google Play">
+          <svg xmlns="http://www.w3.org/2000/svg" width="200" height="60" viewBox="0 0 512 152" aria-hidden="true">
+            <rect width="512" height="152" fill="black" rx="8" ry="8"/>
+            <text x="130" y="95" font-family="Arial, sans-serif" font-size="40" fill="white">Google Play</text>
+            <polygon points="40,25 100,75 40,125" fill="#34A853"/>
+            <polygon points="40,25 40,125 75,100" fill="#FBBC05"/>
+            <polygon points="40,25 75,50 100,75 75,100 40,125" fill="#4285F4" fill-opacity="0.7"/>
+            <polygon points="75,50 100,75 75,100" fill="#EA4335"/>
+          </svg>
+        </a>
         <a href="#features" class="btn ghost">Learn More</a>
       </div>
       <p class="note">Starting at £0 / Free app</p>
@@ -194,7 +214,16 @@
     <div class="card">
       <h2>Free forever</h2>
       <p>Swipelist<br><small>Optional Pro coming later.</small></p>
-      <a href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" class="btn primary" target="_blank" rel="noopener">Get The App</a>
+      <a class="google-play-badge" href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" target="_blank" rel="noopener noreferrer" aria-label="Get it on Google Play">
+        <svg xmlns="http://www.w3.org/2000/svg" width="200" height="60" viewBox="0 0 512 152" aria-hidden="true">
+          <rect width="512" height="152" fill="black" rx="8" ry="8"/>
+          <text x="130" y="95" font-family="Arial, sans-serif" font-size="40" fill="white">Google Play</text>
+          <polygon points="40,25 100,75 40,125" fill="#34A853"/>
+          <polygon points="40,25 40,125 75,100" fill="#FBBC05"/>
+          <polygon points="40,25 75,50 100,75 75,100 40,125" fill="#4285F4" fill-opacity="0.7"/>
+          <polygon points="75,50 100,75 75,100" fill="#EA4335"/>
+        </svg>
+      </a>
     </div>
   </section>
   <section class="faq">

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -31,7 +31,18 @@
         <li><a href="/#features">Features</a></li>
         <li><a href="/#pricing">Pricing</a></li>
         <li><a href="/#contact">Contact</a></li>
-        <li><a class="btn primary" href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" target="_blank" rel="noopener">Get the App</a></li>
+        <li>
+          <a class="google-play-badge" href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" target="_blank" rel="noopener noreferrer" aria-label="Get it on Google Play">
+            <svg xmlns="http://www.w3.org/2000/svg" width="200" height="60" viewBox="0 0 512 152" aria-hidden="true">
+              <rect width="512" height="152" fill="black" rx="8" ry="8"/>
+              <text x="130" y="95" font-family="Arial, sans-serif" font-size="40" fill="white">Google Play</text>
+              <polygon points="40,25 100,75 40,125" fill="#34A853"/>
+              <polygon points="40,25 40,125 75,100" fill="#FBBC05"/>
+              <polygon points="40,25 75,50 100,75 75,100 40,125" fill="#4285F4" fill-opacity="0.7"/>
+              <polygon points="75,50 100,75 75,100" fill="#EA4335"/>
+            </svg>
+          </a>
+        </li>
       </ul>
     </nav>
   </div>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -27,6 +27,9 @@ nav a:hover,nav a:focus{color:var(--blue-700);}
 .btn.primary:hover,.btn.primary:focus{background:var(--blue-700);border-color:var(--blue-700);}
 .btn.ghost{background:transparent;color:var(--blue-500);}
 .btn.ghost:hover,.btn.ghost:focus{background:var(--blue-50);}
+.google-play-badge{display:inline-flex;align-items:center;justify-content:center;width:clamp(140px,40vw,200px);border-radius:8px;overflow:hidden;box-shadow:0 8px 20px rgba(10,134,198,0.18);transition:transform .2s ease,box-shadow .2s ease;}
+.google-play-badge svg{display:block;width:100%;height:auto;}
+.google-play-badge:hover,.google-play-badge:focus-visible{transform:translateY(-1px);box-shadow:0 12px 28px rgba(10,134,198,0.25);}
 .hero{display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;padding:4rem 0;background:linear-gradient(135deg,var(--blue-50),var(--bg));position:relative;overflow:hidden;}
 .hero-text{flex:1 1 400px;max-width:500px;padding:1rem;}
 .hero-text h1{font-size:2.5rem;line-height:1.2;margin-top:0;}
@@ -57,6 +60,7 @@ nav a:hover,nav a:focus{color:var(--blue-700);}
 .pricing .card{background:var(--blue-700);color:#fff;padding:3rem;border-radius:12px;text-align:center;max-width:400px;margin:0 auto;}
 .pricing .card small{display:block;color:var(--blue-50);margin-top:.5rem;}
 .pricing .card .btn{margin-top:1.5rem;}
+.pricing .card .google-play-badge{margin:1.5rem auto 0;}
 .faq{background:var(--card);padding:4rem 0;}
 .accordion .item{border-bottom:1px solid var(--blue-50);}
 .accordion button{width:100%;text-align:left;background:none;border:none;padding:1rem;font-size:1rem;font-weight:600;color:var(--ink);display:flex;justify-content:space-between;align-items:center;cursor:pointer;}


### PR DESCRIPTION
## Summary
- replace text-based Play Store links across the marketing pages with an inline "Get it on Google Play" SVG badge
- add styling for the badge so it scales responsively and fits existing button spacing, including in the pricing card layout

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d2d92d87e48322b736d24b63fb0438