### PR TITLE
Add Google Play badge to site footers

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -250,6 +250,9 @@
       <a href="#contact">Contact</a>
       <a href="/privacy">Privacy Policy</a>
     </nav>
+    <a href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" target="_blank" rel="noopener noreferrer">
+      <img src="/docs/assets/images/google-play-badge.png" alt="Get it on Google Play" style="height:60px; max-width:100%;" />
+    </a>
     <div class="social">
       <a href="https://twitter.com" aria-label="Twitter"><svg class="icon" aria-hidden="true"><use href="assets/icons.svg#icon-twitter"></use></svg></a>
       <a href="https://github.com" aria-label="GitHub"><svg class="icon" aria-hidden="true"><use href="assets/icons.svg#icon-github"></use></svg></a>

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -118,6 +118,9 @@
       <a href="/#contact">Contact</a>
       <a href="/privacy">Privacy Policy</a>
     </nav>
+    <a href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" target="_blank" rel="noopener noreferrer">
+      <img src="/docs/assets/images/google-play-badge.png" alt="Get it on Google Play" style="height:60px; max-width:100%;" />
+    </a>
     <div class="social">
       <a href="https://twitter.com" aria-label="Twitter"><svg class="icon" aria-hidden="true"><use href="../assets/icons.svg#icon-twitter"></use></svg></a>
       <a href="https://github.com" aria-label="GitHub"><svg class="icon" aria-hidden="true"><use href="../assets/icons.svg#icon-github"></use></svg></a>


### PR DESCRIPTION
## Summary
- add the Google Play badge CTA to the main site footer
- mirror the badge CTA in the privacy policy footer so all Play Store links use the same snippet

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d2e7ae0e588322a4e214da03cfc2e6