### PR TITLE
Fix Google Play badge image paths

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -63,7 +63,7 @@
         <li><a href="#contact">Contact</a></li>
         <li>
           <a href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" target="_blank" rel="noopener noreferrer">
-            <img src="/docs/assets/images/google-play-badge.png" alt="Get it on Google Play" style="height:60px; max-width:100%;" />
+            <img src="/assets/images/google-play-badge.png" alt="Get it on Google Play" style="height:60px; max-width:100%;" />
           </a>
         </li>
       </ul>
@@ -78,7 +78,7 @@
       <p>Swipelist auto-sorts your list by the order you shop, so you fly through the store without back-tracking.</p>
       <div class="actions">
         <a href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" target="_blank" rel="noopener noreferrer">
-          <img src="/docs/assets/images/google-play-badge.png" alt="Get it on Google Play" style="height:60px; max-width:100%;" />
+          <img src="/assets/images/google-play-badge.png" alt="Get it on Google Play" style="height:60px; max-width:100%;" />
         </a>
         <a href="#features" class="btn ghost">Learn More</a>
       </div>
@@ -201,7 +201,7 @@
       <h2>Free forever</h2>
       <p>Swipelist<br><small>Optional Pro coming later.</small></p>
       <a href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" target="_blank" rel="noopener noreferrer">
-        <img src="/docs/assets/images/google-play-badge.png" alt="Get it on Google Play" style="height:60px; max-width:100%;" />
+        <img src="/assets/images/google-play-badge.png" alt="Get it on Google Play" style="height:60px; max-width:100%;" />
       </a>
     </div>
   </section>
@@ -251,7 +251,7 @@
       <a href="/privacy">Privacy Policy</a>
     </nav>
     <a href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" target="_blank" rel="noopener noreferrer">
-      <img src="/docs/assets/images/google-play-badge.png" alt="Get it on Google Play" style="height:60px; max-width:100%;" />
+      <img src="/assets/images/google-play-badge.png" alt="Get it on Google Play" style="height:60px; max-width:100%;" />
     </a>
     <div class="social">
       <a href="https://twitter.com" aria-label="Twitter"><svg class="icon" aria-hidden="true"><use href="assets/icons.svg#icon-twitter"></use></svg></a>

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -33,7 +33,7 @@
         <li><a href="/#contact">Contact</a></li>
         <li>
           <a href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" target="_blank" rel="noopener noreferrer">
-            <img src="/docs/assets/images/google-play-badge.png" alt="Get it on Google Play" style="height:60px; max-width:100%;" />
+            <img src="/assets/images/google-play-badge.png" alt="Get it on Google Play" style="height:60px; max-width:100%;" />
           </a>
         </li>
       </ul>
@@ -119,7 +119,7 @@
       <a href="/privacy">Privacy Policy</a>
     </nav>
     <a href="https://play.google.com/store/apps/details?id=com.terryreed.swipelist" target="_blank" rel="noopener noreferrer">
-      <img src="/docs/assets/images/google-play-badge.png" alt="Get it on Google Play" style="height:60px; max-width:100%;" />
+      <img src="/assets/images/google-play-badge.png" alt="Get it on Google Play" style="height:60px; max-width:100%;" />
     </a>
     <div class="social">
       <a href="https://twitter.com" aria-label="Twitter"><svg class="icon" aria-hidden="true"><use href="../assets/icons.svg#icon-twitter"></use></svg></a>


### PR DESCRIPTION
## Summary
- update Google Play badge image references to use the GitHub Pages path so the badge loads correctly across the site

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2ea96292c832283cc815e8c0807e3