### PR TITLE
Add Google AdSense script to site pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5403961907571147" crossorigin="anonymous"></script>
   <title>Swipelist</title>
   <meta name="description" content="Swipelist auto-sorts your list by the order you shop, so you fly through the store without back-tracking.">
   <link rel="icon" href="favicon.svg" type="image/svg+xml">

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5403961907571147" crossorigin="anonymous"></script>
   <title>Privacy Policy - Swipelist</title>
   <meta name="description" content="Read the Swipelist Privacy Policy to learn how we collect, use, and protect your data.">
   <link rel="icon" href="../favicon.svg" type="image/svg+xml">


### PR DESCRIPTION
## Summary
- add the Google AdSense async loader script to the main site head so ads can be served
- include the same AdSense script on the privacy policy page head for consistency

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d428e633808322a5d76bee2aa3d836