### PR TITLE
Add favicon and touch icon links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5403961907571147" crossorigin="anonymous"></script>
   <title>Swipelist</title>
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192x192.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <meta name="description" content="Swipelist auto-sorts your list by the order you shop, so you fly through the store without back-tracking.">
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
   <link rel="manifest" href="manifest.json">


### PR DESCRIPTION
## Summary
- add favicon and touch icon link tags to the head of docs/index.html following the title element

## Testing
- no tests were run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d42d929840832287a473fdc3fec201