### PR TITLE
Add Google Analytics to site pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -46,6 +46,15 @@
     "embedUrl": "https://www.youtube-nocookie.com/embed/ShF5-laPER4"
   }
   </script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-69FS82T6KL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-69FS82T6KL');
+  </script>
 </head>
 <body>
 <header>

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -11,6 +11,15 @@
   <meta name="theme-color" content="#37C1F3">
   <link rel="stylesheet" href="../styles.css">
   <script src="../script.js" defer></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-69FS82T6KL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-69FS82T6KL');
+  </script>
 </head>
 <body>
 <header>


### PR DESCRIPTION
## Summary
- insert the Google Analytics gtag snippet before the closing head tag on the main landing page
- add the same tracking snippet to the privacy policy page to ensure full site coverage

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d430c9e16c832281299f0a42f11e66